### PR TITLE
Fixed typos in the partial metadata import example.

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -4112,7 +4112,7 @@ project.
               "token" : "TOKEN_STRING",
                "overwriteNewer" : "1|0",
                "updateLDMObjects" : "1|0",
-               "turnOffSchdules" "1|0"
+               "turnOffSchedules": "1|0"
               }
             }
 


### PR DESCRIPTION
I've fixed a couple of minor typos in the /gdc/md/{projectID}/maintenance/partialmdimport command.

On a related note, the parameters documented as optional might need a review.
When I don't include 'overwriteNewer' or 'updateLDMObjects', I receive an error "Key 'overwriteNewer|updateLDMObjects' is compulsory."
Conversely, I haven't found a situation where 'turnOffSchedules' does not result in an "Key turnOffSchedules is redundant." error.

This could certainly be due to my particular request -- I didn't spend much time investigating -- but the documentation could be a little clearer around these parameters.

Thanks!